### PR TITLE
Fix: DatePickerInList 재사용 편리하게 수정 #16

### DIFF
--- a/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
+++ b/ReadingFrame/ReadingFrame.xcodeproj/project.pbxproj
@@ -54,6 +54,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		C59055262B7E67F600AD0A73 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				C595A2032B7BDE87006D88EC /* DatePickerInList.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		C595A1DC2B7A89D8006D88EC /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -66,6 +74,7 @@
 		C595A1E12B7A9FB7006D88EC /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				C59055262B7E67F600AD0A73 /* Helper */,
 				C595A1F92B7B8A16006D88EC /* Models */,
 				C595A1E22B7A9FC0006D88EC /* Views */,
 			);
@@ -173,7 +182,6 @@
 			isa = PBXGroup;
 			children = (
 				C595A2012B7BCB10006D88EC /* SelectBookTypeView.swift */,
-				C595A2032B7BDE87006D88EC /* DatePickerInList.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -468,7 +476,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -510,7 +518,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/ReadingFrame/ReadingFrame/BookInfo/Views/RegisterBook.swift
+++ b/ReadingFrame/ReadingFrame/BookInfo/Views/RegisterBook.swift
@@ -124,8 +124,13 @@ struct RegisterBook: View {
                     DatePickerInList(selectedDate: $startDate,
                                      isDatePickerVisible: $isStartDatePickerVisible,
                                      dateRange: startDateRange,
-                                     isAnotherDatePickerVisible:$isRecentDatePickerVisible,
                                      listText: "읽기 시작한 날")
+                    // 읽기 시작한 날 DatePicker가 활성화되면 다읽은날 DatePicker는 비활성화
+                    .onChange(of: isStartDatePickerVisible) {
+                        if isStartDatePickerVisible {
+                            isRecentDatePickerVisible = false
+                        }
+                    }
                     
                     // MARK: 다읽은 날 입력
                     // readingStatus 다읽음일때만 보여주도록
@@ -133,8 +138,13 @@ struct RegisterBook: View {
                         DatePickerInList(selectedDate: $recentDate,
                                          isDatePickerVisible: $isRecentDatePickerVisible,
                                          dateRange: recentDateRange,
-                                         isAnotherDatePickerVisible:$isStartDatePickerVisible,
                                          listText: "다 읽은 날")
+                        // 읽기 시작한 날 DatePicker가 활성화되면 다읽은날 DatePicker는 비활성화
+                        .onChange(of: isRecentDatePickerVisible) {
+                            if isRecentDatePickerVisible {
+                                isStartDatePickerVisible = false
+                            }
+                        }
                         
                     }
                     

--- a/ReadingFrame/ReadingFrame/Common/Helper/DatePickerInList.swift
+++ b/ReadingFrame/ReadingFrame/Common/Helper/DatePickerInList.swift
@@ -13,10 +13,7 @@ struct DatePickerInList: View {
     @Binding var selectedDate: Date                 /// 선택한 날짜(호출한 뷰로 전달)
     @Binding var isDatePickerVisible: Bool          /// 현재 뷰에서 달력 graphical DatePicker 보여주는지 여부
     var dateRange: ClosedRange<Date>                /// DatePicker 만들 때 in: 에 전달에줄 날짜 범위
-    
-    /// 근처에 다른 DatePickerInList가 있다면 하나의 DatePicker만 보여주기 위한 변수
-    @Binding var isAnotherDatePickerVisible: Bool
-    
+        
     var listText: String = "날짜 선택"  /// 어떤 날짜 선택하는지 설명용 텍스트
     
     /// 버튼에 들어갈 날짜 text
@@ -35,18 +32,22 @@ struct DatePickerInList: View {
 
         // MARK: 첫번째 row: 날짜 선택 button
         HStack {
+            // 선택하는 날짜 설명 텍스트
             Text(listText)
+            
             Spacer()
+            
+            // 날짜 버튼
             Button {
+                // DatePicker 활성화 여부 변경
                 isDatePickerVisible.toggle()
-                isAnotherDatePickerVisible = false
-                
-                print("current: ", isDatePickerVisible, "another: ", isAnotherDatePickerVisible)
+
             } label: {
+                // 날짜 버튼 텍스트
                 Text(dateString)
+                    // 활성화될 때 accentColor로 변경
+                    .foregroundStyle(isDatePickerVisible ? Color.accentColor : Color.primary)
             }
-            // 활성화될 때 accentColor로 변경
-            .foregroundStyle(isDatePickerVisible ? Color.accentColor : Color.primary)
             // 기존 DatePicker 흉내내기(회색 박스 생김)
             .buttonStyle(.bordered)
         }


### PR DESCRIPTION
- DatePickerInList 매개변수 `isAnotherDatePickerVisible` 대신, RegisterBook에서 `.onChange` 이용해서 DatePicker 둘 중 하나만 활성화시키도록 수정했습니다.
- DatePickerInList.swift 파일 위치 Common > Helpers로 이동해서 재사용가능한 파일임을 쉽게 확인할 수 있도록 했습니다.
- **iOS 최소버전이 17.0으로 수정되었습니다**.